### PR TITLE
Add MariaDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ public void connect() {
 }
 ````
 
+### With MariaDB
+
+````java
+public void connect() {
+    DatabaseConfiguration configuration=DatabaseConfiguration.createMariaDb(<user>,<password>,<port>,<host>,<database>);
+    DatabaseConnection connection=new MariaDbConnection(configuration);
+}
+````
+
 ### With SQLITE
 
 ````java

--- a/src/main/java/fr/maxlego08/sarah/DatabaseConfiguration.java
+++ b/src/main/java/fr/maxlego08/sarah/DatabaseConfiguration.java
@@ -39,8 +39,16 @@ public class DatabaseConfiguration {
         return new DatabaseConfiguration(null, user, password, port, host, database, false, DatabaseType.MYSQL);
     }
 
+    public static DatabaseConfiguration createMariaDb(String user, String password, int port, String host, String database) {
+        return new DatabaseConfiguration(null, user, password, port, host, database, false, DatabaseType.MARIADB);
+    }
+
     public static DatabaseConfiguration create(String user, String password, int port, String host, String database, boolean debug) {
         return new DatabaseConfiguration(null, user, password, port, host, database, debug, DatabaseType.MYSQL);
+    }
+
+    public static DatabaseConfiguration createMariaDb(String user, String password, int port, String host, String database, boolean debug) {
+        return new DatabaseConfiguration(null, user, password, port, host, database, debug, DatabaseType.MARIADB);
     }
 
     public static DatabaseConfiguration create(String user, String password, String host, String database, DatabaseType databaseType) {
@@ -49,6 +57,10 @@ public class DatabaseConfiguration {
 
     public static DatabaseConfiguration create(String user, String password, int port, String host, String database, boolean debug, DatabaseType databaseType) {
         return new DatabaseConfiguration(null, user, password, port, host, database, debug, databaseType);
+    }
+
+    public static DatabaseConfiguration createMariaDb(String user, String password, String host, String database) {
+        return new DatabaseConfiguration(null, user, password, 3306, host, database, false, DatabaseType.MARIADB);
     }
 
     public static DatabaseConfiguration sqlite(boolean debug) {

--- a/src/main/java/fr/maxlego08/sarah/DatabaseConnection.java
+++ b/src/main/java/fr/maxlego08/sarah/DatabaseConnection.java
@@ -1,5 +1,7 @@
 package fr.maxlego08.sarah;
 
+import fr.maxlego08.sarah.database.DatabaseType;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -32,8 +34,14 @@ public abstract class DatabaseConnection {
      */
     public boolean isValid() {
 
+        DatabaseType databaseType = this.databaseConfiguration.getDatabaseType();
+
         try {
-            Class.forName("com.mysql.cj.jdbc.Driver");
+            if (databaseType == DatabaseType.MARIADB) {
+                Class.forName("org.mariadb.jdbc.Driver");
+            } else {
+                Class.forName("com.mysql.cj.jdbc.Driver");
+            }
         } catch (Exception ignored) {
         }
 

--- a/src/main/java/fr/maxlego08/sarah/HikariDatabaseConnection.java
+++ b/src/main/java/fr/maxlego08/sarah/HikariDatabaseConnection.java
@@ -2,6 +2,7 @@ package fr.maxlego08.sarah;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import fr.maxlego08.sarah.database.DatabaseType;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -37,7 +38,14 @@ public class HikariDatabaseConnection extends DatabaseConnection {
         HikariConfig config = new HikariConfig();
 
         config.setPoolName("sarah-" + POOL_COUNTER.getAndIncrement());
-        config.setJdbcUrl("jdbc:mysql://" + databaseConfiguration.getHost() + ":" + databaseConfiguration.getPort() + "/" + databaseConfiguration.getDatabase() + "?allowMultiQueries=true");
+
+        DatabaseType databaseType = databaseConfiguration.getDatabaseType();
+        String jdbcPrefix = databaseType == DatabaseType.MARIADB ? "jdbc:mariadb://" : "jdbc:mysql://";
+        config.setJdbcUrl(jdbcPrefix + databaseConfiguration.getHost() + ":" + databaseConfiguration.getPort() + "/" + databaseConfiguration.getDatabase() + "?allowMultiQueries=true");
+
+        if (databaseType == DatabaseType.MARIADB) {
+            config.setDriverClassName("org.mariadb.jdbc.Driver");
+        }
 
         config.setUsername(databaseConfiguration.getUser());
         config.setPassword(databaseConfiguration.getPassword());

--- a/src/main/java/fr/maxlego08/sarah/MariaDbConnection.java
+++ b/src/main/java/fr/maxlego08/sarah/MariaDbConnection.java
@@ -1,0 +1,24 @@
+package fr.maxlego08.sarah;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.Properties;
+
+/**
+ * Represents a connection to a MariaDB database.
+ */
+public class MariaDbConnection extends DatabaseConnection {
+
+    public MariaDbConnection(DatabaseConfiguration databaseConfiguration) {
+        super(databaseConfiguration);
+    }
+
+    @Override
+    public Connection connectToDatabase() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("useSSL", "false");
+        properties.setProperty("user", databaseConfiguration.getUser());
+        properties.setProperty("password", databaseConfiguration.getPassword());
+        return DriverManager.getConnection("jdbc:mariadb://" + databaseConfiguration.getHost() + ":" + databaseConfiguration.getPort() + "/" + databaseConfiguration.getDatabase() + "?allowMultiQueries=true", properties);
+    }
+}

--- a/src/main/java/fr/maxlego08/sarah/database/DatabaseType.java
+++ b/src/main/java/fr/maxlego08/sarah/database/DatabaseType.java
@@ -3,6 +3,7 @@ package fr.maxlego08.sarah.database;
 public enum DatabaseType {
 
     MYSQL,
+    MARIADB,
     SQLITE,
 
 }


### PR DESCRIPTION
## Summary
- add a MariaDB connection implementation and database type
- extend the configuration and Hikari connector to work with MariaDB
- document the MariaDB setup alongside existing connection instructions

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68dd395b12e883218e820fab313c99a6