### PR TITLE
Allow configuring HikariCP pool size limits

### DIFF
--- a/src/main/java/fr/maxlego08/sarah/DatabaseConfiguration.java
+++ b/src/main/java/fr/maxlego08/sarah/DatabaseConfiguration.java
@@ -18,9 +18,17 @@ public class DatabaseConfiguration {
     private final String database;
     private final boolean debug;
     private final DatabaseType databaseType;
+    private final Integer maximumPoolSize;
+    private final Integer minimumIdle;
 
     public DatabaseConfiguration(String tablePrefix, String user, String password, int port, String host,
                                  String database, boolean debug, DatabaseType databaseType) {
+        this(tablePrefix, user, password, port, host, database, debug, databaseType, null, null);
+    }
+
+    public DatabaseConfiguration(String tablePrefix, String user, String password, int port, String host,
+                                 String database, boolean debug, DatabaseType databaseType,
+                                 Integer maximumPoolSize, Integer minimumIdle) {
         this.tablePrefix = tablePrefix;
         this.user = user;
         this.password = password;
@@ -29,6 +37,8 @@ public class DatabaseConfiguration {
         this.database = database;
         this.debug = debug;
         this.databaseType = databaseType;
+        this.maximumPoolSize = maximumPoolSize;
+        this.minimumIdle = minimumIdle;
     }
 
     public static DatabaseConfiguration create(String user, String password, int port, String host, String database, DatabaseType databaseType) {
@@ -103,6 +113,19 @@ public class DatabaseConfiguration {
         return databaseType;
     }
 
+    public Integer getMaximumPoolSize() {
+        return maximumPoolSize;
+    }
+
+    public Integer getMinimumIdle() {
+        return minimumIdle;
+    }
+
+    public DatabaseConfiguration withPoolSettings(Integer maximumPoolSize, Integer minimumIdle) {
+        return new DatabaseConfiguration(this.tablePrefix, this.user, this.password, this.port, this.host,
+                this.database, this.debug, this.databaseType, maximumPoolSize, minimumIdle);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -115,12 +138,14 @@ public class DatabaseConfiguration {
                 Objects.equals(password, that.password) &&
                 Objects.equals(host, that.host) &&
                 Objects.equals(database, that.database) &&
-                databaseType == that.databaseType;
+                databaseType == that.databaseType &&
+                Objects.equals(maximumPoolSize, that.maximumPoolSize) &&
+                Objects.equals(minimumIdle, that.minimumIdle);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tablePrefix, user, password, port, host, database, debug, databaseType);
+        return Objects.hash(tablePrefix, user, password, port, host, database, debug, databaseType, maximumPoolSize, minimumIdle);
     }
 
     @Override
@@ -134,6 +159,8 @@ public class DatabaseConfiguration {
                 ", database='" + database + '\'' +
                 ", debug=" + debug +
                 ", databaseType=" + databaseType +
+                ", maximumPoolSize=" + maximumPoolSize +
+                ", minimumIdle=" + minimumIdle +
                 '}';
     }
 }

--- a/src/main/java/fr/maxlego08/sarah/HikariDatabaseConnection.java
+++ b/src/main/java/fr/maxlego08/sarah/HikariDatabaseConnection.java
@@ -53,8 +53,20 @@ public class HikariDatabaseConnection extends DatabaseConnection {
         config.setPassword(databaseConfiguration.getPassword());
 
         // Pooling
-        config.setMaximumPoolSize(MAXIMUM_POOL_SIZE);
-        config.setMinimumIdle(MINIMUM_IDLE);
+        int configuredMaxPoolSize = MAXIMUM_POOL_SIZE;
+        Integer maxPoolSize = databaseConfiguration.getMaximumPoolSize();
+        if (maxPoolSize != null && maxPoolSize > 0) {
+            configuredMaxPoolSize = maxPoolSize;
+        }
+
+        int configuredMinimumIdle = Math.min(configuredMaxPoolSize, MINIMUM_IDLE);
+        Integer minIdle = databaseConfiguration.getMinimumIdle();
+        if (minIdle != null && minIdle >= 0) {
+            configuredMinimumIdle = Math.min(configuredMaxPoolSize, minIdle);
+        }
+
+        config.setMaximumPoolSize(configuredMaxPoolSize);
+        config.setMinimumIdle(configuredMinimumIdle);
         config.setMaxLifetime(MAX_LIFETIME);
         config.setConnectionTimeout(CONNECTION_TIMEOUT);
         config.setLeakDetectionThreshold(LEAK_DETECTION_THRESHOLD);


### PR DESCRIPTION
## Summary
- allow `DatabaseConfiguration` to carry optional pool sizing overrides
- honor the optional maximum pool size and minimum idle limits when configuring HikariCP

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e4ef4c82688321b34d14fda6e3ac4a